### PR TITLE
Dependencies and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ effect, you must specify `-s` on the command line. For usage info, use `cmatrix 
 ### Dependencies
 You'll probably need a decent ncurses library to get this to work.
 
+On _Fedora Linux_, for example:
+
+```
+sudo dnf install autoconf automake gcc gcc-c++ git libtool make nasm pkgconfig ncurses ncurses-devel
+```
+
 ### Building and installing cmatrix
 To install cmatrix, use either of the following methods from within the cmatrix directory.
 
@@ -22,7 +28,7 @@ To install cmatrix, use either of the following methods from within the cmatrix 
 autoreconf -i  # skip if using released tarball
 ./configure
 make
-make install
+sudo make install
 ```
 
 #### Using CMake
@@ -35,7 +41,7 @@ cmake ..
 # or to install to "/usr"
 #cmake -DCMAKE_INSTALL_PREFIX=/usr ..
 make
-make install
+sudo make install
 ```
 
 ### Running cmatrix
@@ -43,6 +49,8 @@ After you have installed cmatrix just run `cmatrix` to run cmatrix :)
 
 _To get the program to look most like the movie, use `cmatrix -lba`_
 _To get the program to look most like the Win/Mac screensaver, use `cmatrix -ol`_
+
+In the _launcher_ directory there are some scripts as examples, that you can consider to use to launch `cmatrix` by opening a _terminal_.
 
 ### Valuable information
 If you have any suggestions/flames/patches to send, please feel free to

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ After you have installed cmatrix just run `cmatrix` to run cmatrix :)
 _To get the program to look most like the movie, use `cmatrix -lba`_
 _To get the program to look most like the Win/Mac screensaver, use `cmatrix -ol`_
 
-In the _launcher_ directory there are some scripts as examples, that you can consider to use to launch `cmatrix` by opening a _terminal_.
+In the _launcher_ directory there are some scripts as examples, that you can consider to use as custom command by opening a _terminal_.
 
 ### Valuable information
 If you have any suggestions/flames/patches to send, please feel free to

--- a/launcher/cmatrix_launcher_black.sh
+++ b/launcher/cmatrix_launcher_black.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cmatrix -baC black
+/bin/bash

--- a/launcher/cmatrix_launcher_blue.sh
+++ b/launcher/cmatrix_launcher_blue.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cmatrix -baC blue
+/bin/bash

--- a/launcher/cmatrix_launcher_cyan.sh
+++ b/launcher/cmatrix_launcher_cyan.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cmatrix -baC cyan
+/bin/bash

--- a/launcher/cmatrix_launcher_green.sh
+++ b/launcher/cmatrix_launcher_green.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cmatrix -baC green
+/bin/bash

--- a/launcher/cmatrix_launcher_magenta.sh
+++ b/launcher/cmatrix_launcher_magenta.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cmatrix -baC magenta
+/bin/bash

--- a/launcher/cmatrix_launcher_red.sh
+++ b/launcher/cmatrix_launcher_red.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cmatrix -baC red
+/bin/bash

--- a/launcher/cmatrix_launcher_white.sh
+++ b/launcher/cmatrix_launcher_white.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cmatrix -baC white
+/bin/bash

--- a/launcher/cmatrix_launcher_yellow.sh
+++ b/launcher/cmatrix_launcher_yellow.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cmatrix -baC yellow
+/bin/bash


### PR DESCRIPTION
Added the example command for the installation of the necessary _dependencies_ to compile `cmatrix` on Fedora and some `scripts` about how to use `cmatrix` in a terminal